### PR TITLE
Updated the readme for OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,35 @@
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
-# BHoM Unreal_Toolkit
+# BHoM
 
 A great place to start is reading our Wiki [here](https://github.com/BHoM/documentation/wiki) including pages like the [Structure of the BHoM](https://github.com/BHoM/documentation/wiki/Structure-of-the-BHoM) and [Using the BHoM](https://github.com/BHoM/documentation/wiki/Using-the-BHoM).
+
+## Quick start ##
+
+Try the [installer](http://bhom.xyz/assets/installers/v2.1/BHoM%20Alpha%20v2.1.0.5%20Installer.exe) and a selection of [sample scripts](https://github.com/BHoM/samples).
+
+
+
+## Building the BHoM and the Toolkits from Source ##
+You will need the following to build BHoM:
+
+- Microsoft Visual Studio 2013 or higher
+- Microsoft .NET Framework 4.0 and above (included with Visual Studio 2013)
+- Note that there are no software - specific dependencies (only operating system relevant), this is specific: BHoM is a software agnostic object model.
+
+
+### Clone and build the Core BHoM Repos
+More specific instructions on this can be found on the [Unreal_Toolkit wiki](https://github.com/BuroHappoldEngineering/Unreal_Toolkit/wiki/Unreal_Toolkit-wiki).
+
+
+
+## Want to contribute? ##
+
+BHoM is an open-source project and would be nothing without its community. Take a look at our contributing guidelines and tips [here](https://github.com/BHoM/BHoM/blob/master/CONTRIBUTING.md).
+
+
+## Licence ##
+
+BHoM is free software licenced under GNU Lesser General Public Licence - [https://www.gnu.org/licenses/lgpl-3.0.html](https://www.gnu.org/licenses/lgpl-3.0.html)  
+Each contributor holds copyright over their respective contributions.
+The project versioning (Git) records all such contribution source information.
+See [LICENSE](https://github.com/BHoM/BHoM/blob/master/LICENSE) and [COPYRIGHT_HEADER](https://github.com/BHoM/BHoM/blob/master/COPYRIGHT_HEADER.txt).


### PR DESCRIPTION
Moved most of the section `Building the BHoM and the Toolkits from Source` from the ReadMe into [Unreal_Toolkit wiki](https://github.com/BuroHappoldEngineering/Unreal_Toolkit/wiki/Unreal_Toolkit-wiki).
Not sure whether that's correct – given the early stage of this toolkit I thought it was the most correct approach. This way the main wiki page contains most of the needed information for newcomers.

   
### Issues addressed by this PR

Closes #11